### PR TITLE
Update accessor_types.h

### DIFF
--- a/include/sycldnn/accessor_types.h
+++ b/include/sycldnn/accessor_types.h
@@ -71,7 +71,7 @@ struct BaseAccessor {
    * Get the underlying pointer from the accessor.
    * \return A global pointer to the underlying memory.
    */
-  MultiPtr get_pointer() const { return acc_.get_pointer() + offset_; }
+  MultiPtr get_pointer() const { return acc_.get_pointer(); }
 
   /**
    * Get a reference to the underlying SYCL accessor.


### PR DESCRIPTION
Offset had been applied already at construction

Was causing segmentation faults with DPC++. I am surprised this behavior was not seen with other compilers.